### PR TITLE
Update bazel class name

### DIFF
--- a/bazel@0.14.1.rb
+++ b/bazel@0.14.1.rb
@@ -1,4 +1,4 @@
-class Bazel < Formula
+class BazelAT0141 < Formula
   desc "Google's own build tool"
   homepage "https://bazel.build/"
   url "https://github.com/bazelbuild/bazel/releases/download/0.14.1/bazel-0.14.1-dist.zip"


### PR DESCRIPTION
Change the class name to allow us to pin to bazel 14.1; the current version doesn't allow pinning